### PR TITLE
Example of publishing with Go

### DIFF
--- a/gcbuild/cloudbuild.yml
+++ b/gcbuild/cloudbuild.yml
@@ -16,9 +16,13 @@ steps:
 - name: gcr.io/cloud-builders/docker
   args: [
     'build', '--network=cloudbuild',
+    # Image is only intended to be used within the Cloud Build run.
     '-t', 'publish-images',
     '-f', 'gcbuild/publish-images/Dockerfile',
     '.'
   ]
+# We must use the image from the last step to leverage Cloud Build's access to GCR.
+# If we use Docker and `docker run publish-images`, this step will fail due to permission
+# issues.
 - name: publish-images
   entrypoint: /templates/publish-images

--- a/gcbuild/cloudbuild.yml
+++ b/gcbuild/cloudbuild.yml
@@ -1,0 +1,24 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+- name: gcr.io/cloud-builders/docker
+  args: [
+    'build', '--network=cloudbuild',
+    '-t', 'publish-images',
+    '-f', 'gcbuild/publish-images/Dockerfile',
+    '.'
+  ]
+- name: publish-images
+  entrypoint: /templates/publish-images

--- a/gcbuild/publish-images/Dockerfile
+++ b/gcbuild/publish-images/Dockerfile
@@ -1,0 +1,26 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang AS gobuild
+WORKDIR /go/src/github.com/GoogleCloudPlatform/DataflowTemplates
+COPY gcbuild/ ./gcbuild/
+RUN go mod init
+RUN go build ./gcbuild/publish-images
+
+FROM maven:3-jdk-8
+WORKDIR /templates
+COPY --from=gobuild /go/src/github.com/GoogleCloudPlatform/DataflowTemplates/publish-images ./
+COPY v2/ ./v2/
+
+# Proper entrypoint is /templates/publish-images

--- a/gcbuild/publish-images/publish.go
+++ b/gcbuild/publish-images/publish.go
@@ -55,6 +55,9 @@ func publish(packageName string, image string) error {
 }
 
 func main() {
+	// Realistically, the first step will be to check if the images already exist
+	// in GCR. Packaging and pushing them is relatively expensive (multiple minutes).
+
 	for k, v := range sharedPackages {
 		for _, image := range v {
 			if err := publish(k, image); err != nil {

--- a/gcbuild/publish-images/publish.go
+++ b/gcbuild/publish-images/publish.go
@@ -1,0 +1,65 @@
+/* Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os/exec"
+)
+
+// We'd have an array here for packages without multiple images.
+
+var sharedPackages = map[string][]string {
+	"pubsub-binary-to-bigquery": {"pubsub-proto-to-bigquery", "pubsub-avro-to-bigquery"},
+}
+
+func publish(packageName string, image string) error {
+	args := []string {
+		"package", "-f", "v2/pom.xml",
+		"-Dmaven.test.skip",
+		// In reality, the project would be a flag.
+		fmt.Sprintf("-Dimage=gcr.io/zhoufek-test-331019/rc/%s", image),
+		"-Dbase-container-image=gcr.io/dataflow-templates-base/java8-template-launcher-base",
+		"-Dbase-container-image.version=latest",
+		fmt.Sprintf("-Dapp-root=/template/%s", image),
+		fmt.Sprintf("-Dcommand-spec=/template/%[1]s/resources/%[1]s-command-spec.json", image),
+		"-pl", packageName, "-am", "-ntp",
+	}
+
+	cmd := exec.Command("mvn", args...)
+
+	stdout, _ := cmd.StdoutPipe()
+	cmd.Start()
+
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		fmt.Println(scanner.Text())
+	}
+
+	return cmd.Wait()
+}
+
+func main() {
+	for k, v := range sharedPackages {
+		for _, image := range v {
+			if err := publish(k, image); err != nil {
+				log.Fatalf("Failed when publishing %v: %v", image, err)
+			}
+		}
+	}
+}

--- a/gcbuild/publish-images/publish.go
+++ b/gcbuild/publish-images/publish.go
@@ -30,7 +30,7 @@ var sharedPackages = map[string][]string {
 
 func publish(packageName string, image string) error {
 	args := []string {
-		"package", "-f", "v2/pom.xml",
+		"clean", "package", "-f", "v2/pom.xml",
 		"-Dmaven.test.skip",
 		// In reality, the project would be a flag.
 		fmt.Sprintf("-Dimage=gcr.io/zhoufek-test-331019/rc/%s", image),


### PR DESCRIPTION
This is one option of pushing all our Flex Templates to GCR as part of a release on Cloud Build. Advantages to this are:

- We can expand this to serialize the Classic Templates.
- We can expand this to publish artifacts to Cloud Storage.
- We could add a checkpoint step to avoid re-running in case of retry.
- It's easy to add more Templates.
- If we can figure out some of our Maven problems, Go is great at concurrency.